### PR TITLE
Remove $ from bash command to enable copy-paste

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ A Simple command line utiltiy for waking hosts on a local network. Wakeonlan is 
 First clone the repository, then open a shell terminal and cd to the location of the repository's parent directory, then run...
 
 ```bash
-$ python3 -m pip install wakeonlan
+python3 -m pip install wakeonlan
 
 ```
 to install the wakeonlan command. 


### PR DESCRIPTION
When copying the command from the readme, the extra `$` at the start causes the command to fail. While it does help to provide context in code blocks showing expected output, in the case where it's expected that the user will copy and paste the command, I think it makes sense to remove this character so that the pasted output runs without modification.